### PR TITLE
Specify .rcfile explicitly in pylint pre-commit hook and remove assumptions about project structure.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,5 +20,5 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        args: ["src/", "tests/"]
+        args: ["--rcfile=.pylintrc"]
         additional_dependencies: []


### PR DESCRIPTION
* Retire the use of any assumptions about project structure, which may not be consistent across projects.
* pylint wasn't using the configuration in the pre-commit unless explicitly told to.