### PR TITLE
Switch to artifact upload + deploy-pages action

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -6,6 +6,15 @@ on:
     branches-ignore:
       - gh-pages
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   lint:
     name: Run Linting
@@ -58,19 +67,10 @@ jobs:
           coverage run -m pytest
           coverage html
 
-      - name: Deploy coverage report to GitHub Pages
-        if: success()
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git fetch origin
-          git worktree add gh-pages origin/gh-pages || \
-          git checkout --orphan gh-pages
-          cp -r htmlcov/* gh-pages/
-          cd gh-pages
-          git add .
-          git commit -m "Update coverage report"
-          git push -f origin HEAD:gh-pages
+      - name: Publish coverage to GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: htmlcov
 
       - name: Generate coverage report in console
         run: coverage report
@@ -94,6 +94,22 @@ jobs:
 
       - name: Run pip-audit
         run: pip-audit
+
+  pages:
+    name: Deploy coverage to GitHub Pages
+    if: >-
+      ${{ github.event_name != 'pull_request'
+          && contains(fromJSON('["main","dev"]'), github.ref_name) }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4
+
 
   deploy:
     name: Sample Deploy Step


### PR DESCRIPTION
**ci: publish coverage via Pages artifact + deploy-pages; retire gh-pages worktree**

**Description**

*   Replace manual `gh-pages` worktree push with the GitHub Pages artifact + `deploy-pages` action.
*   Aligns this repo with the TIMES workflow and fixes the pipeline failure caused by the old deploy.
*   Adds required `permissions` and `concurrency` for Pages, and a branch guard for `main`/`dev`.

**Verification**

*   On a push to `main` or `dev`, confirm:
    *   `test` job uploads `htmlcov` via `actions/upload-pages-artifact@v3`.
    *   `pages` job runs `actions/deploy-pages@v4` and prints the Pages URL.
    *   The coverage site renders at the URL from the job output.
*   On PRs or other branches, Pages deploy is skipped.

**Ops notes / follow-ups**

*   Ensure **Settings → Pages → Build and deploy** is set to **GitHub Actions**.
*   Delete the legacy `gh-pages` branch once this is live.