### PR TITLE
ci: add conventional commit validation hooks

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -16,9 +16,70 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  conventional-commits:
+    name: Run Conventional Commits Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for ranges)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package and other dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest coverage
+          pip install .
+          pip install -r requirements-dev.txt
+
+      - name: Compute commit range
+        id: range
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "Not a push event; skipping."
+            exit 0
+          fi
+
+          head_sha="${{ github.sha }}"
+          base_sha="${{ github.event.before }}"
+
+          if [[ "$base_sha" =~ ^0+$ ]]; then
+          base_sha="$(git rev-list --max-parents=0 "$head_sha" | tail -n1)"
+          else
+            # Ensure the 'before' commit exists locally
+            if ! git cat-file -e "$base_sha^{commit}" 2>/dev/null; then
+            # Fetch just that commit (and its objects) efficiently
+            git fetch --no-tags --prune --depth=100 \
+            origin "$base_sha" || git fetch --no-tags --prune origin --depth=0
+            fi
+          fi
+
+          echo "range=$base_sha..$head_sha" >> "$GITHUB_OUTPUT"
+          echo "Using range: $base_sha..$head_sha"
+
+      - name: Run Commitizen check
+        if: ${{ steps.range.outputs.range != '' }}
+        run: |
+          range="${{ steps.range.outputs.range }}"
+          if [ "$(git rev-list --count "$range")" -eq 0 ]; then
+            echo "Range empty; checking last commit only"
+            cz check --message "$(git log -1 --pretty=%B "${{ github.sha }}")"
+          else
+            cz check --rev-range "$range"
+          fi
+
   lint:
     name: Run Linting
     runs-on: ubuntu-latest
+    needs: conventional-commits
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -37,42 +37,33 @@ jobs:
           pip install .
           pip install -r requirements-dev.txt
 
-      - name: Compute commit range
+      - name: Compute feature commit range
         id: range
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.event_name }}" != "push" ]]; then
-            echo "Not a push event; skipping."
-            exit 0
-          fi
-
           head_sha="${{ github.sha }}"
-          base_sha="${{ github.event.before }}"
+          base_branch="main"   #change if default branch is different
 
-          if [[ "$base_sha" =~ ^0+$ ]]; then
-          base_sha="$(git rev-list --max-parents=0 "$head_sha" | tail -n1)"
-          else
-            # Ensure the 'before' commit exists locally
-            if ! git cat-file -e "$base_sha^{commit}" 2>/dev/null; then
-            # Fetch just that commit (and its objects) efficiently
-            git fetch --no-tags --prune --depth=100 \
-            origin "$base_sha" || git fetch --no-tags --prune origin --depth=0
-            fi
-          fi
+          git fetch origin "$base_branch"
+          fork_point="$(git merge-base --fork-point\
+          "origin/${base_branch}" "$head_sha" \
+          || git merge-base "origin/${base_branch}" "$head_sha")"
 
-          echo "range=$base_sha..$head_sha" >> "$GITHUB_OUTPUT"
-          echo "Using range: $base_sha..$head_sha"
+          range="${fork_point}..${head_sha}"
+          echo "range=$range" >> "$GITHUB_OUTPUT"
+          echo "Using feature range: $range"
 
       - name: Run Commitizen check
         if: ${{ steps.range.outputs.range != '' }}
         run: |
           range="${{ steps.range.outputs.range }}"
           if [ "$(git rev-list --count "$range")" -eq 0 ]; then
-            echo "Range empty; checking last commit only"
+            echo "No commits since fork point; checking last commit only"
             cz check --message "$(git log -1 --pretty=%B "${{ github.sha }}")"
           else
+            echo "Checking commits in range: $range"
             cz check --rev-range "$range"
           fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,36 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+    
+      - id: cz-check-any-branch
+        name: commitizen check on any branch (pre-push)
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        entry: |
+          bash -c '
+            status=0
+            while read -r local_ref local_sha remote_ref remote_sha
+            do
+              case "$remote_ref" in
+                refs/heads/*)
+                  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+                    range="$local_sha"
+                  else
+                    range="$remote_sha..$local_sha"
+                  fi
+                  echo "Running cz check for $remote_ref on range: $range"
+                  cz check --rev-range "$range" || status=1
+                  ;;
+                *)
+                  :
+                ;;
+              esac
+            done
+            exit $status
+          '
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.27.0
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,7 @@ repos:
             done
             exit $status
           '
+
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v3.27.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
-    
+
       - id: cz-check-any-branch
         name: commitizen check on any branch (pre-push)
         language: system
@@ -80,7 +80,8 @@ repos:
             do
               case "$remote_ref" in
                 refs/heads/*)
-                  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+                  if [ "$remote_sha" = \
+          "0000000000000000000000000000000000000000" ]; then
                     range="$local_sha"
                   else
                     range="$remote_sha..$local_sha"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,37 +68,9 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-      - id: cz-check-any-branch
-        name: commitizen check on any branch (pre-push)
+      - id: commitizen-local
+        name: commitizen (venv)
+        entry: cz check --commit-msg-file
         language: system
-        pass_filenames: false
-        stages: [pre-push]
-        entry: |
-          bash -c '
-            status=0
-            while read -r local_ref local_sha remote_ref remote_sha
-            do
-              case "$remote_ref" in
-                refs/heads/*)
-                  if [ "$remote_sha" = \
-          "0000000000000000000000000000000000000000" ]; then
-                    range="$local_sha"
-                  else
-                    range="$remote_sha..$local_sha"
-                  fi
-                  echo "Running cz check for $remote_ref on range: $range"
-                  cz check --rev-range "$range" || status=1
-                  ;;
-                *)
-                  :
-                ;;
-              esac
-            done
-            exit $status
-          '
-
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.27.0
-    hooks:
-      - id: commitizen
+        pass_filenames: true
         stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is assumed that the developer is working in Ubuntu (typically within `wsl` on
 
 6.  **Install Pre-commit Hooks:**
     ```bash
-    pre-commit install
+    pre-commit install --install-hooks
     pre-commit install --hook-type commit-msg
     pre-commit install --hook-type pre-push
     ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ https://eeca-nz.github.io/eeca-python-template/
     If any formatter modifies files or a check fails, the commit will be blocked. After fixing issues or adding modified files, commit again.
 
 *   **Conventional Commits:**
-    The pre-commit and pre-push hooks will enforce conventional commits. To find out more visit [www.conventionalcommits.org](https://www.conventionalcommits.org)
+    The pre-commit and pre-push hooks will enforce commit message conventions. To find out more visit [www.conventionalcommits.org](https://www.conventionalcommits.org)
 
 *   **Skipping Hooks (not recommended):**
     ```bash

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ https://eeca-nz.github.io/eeca-python-template/
 *   **Automatic Formatting and Checking:**
     If any formatter modifies files or a check fails, the commit will be blocked. After fixing issues or adding modified files, commit again.
 
+*   **Conventional Commits:**
+    The pre-commit and pre-push hooks will enforce conventional commits. To find out more visit [www.conventionalcommits.org](https://www.conventionalcommits.org)
+
 *   **Skipping Hooks (not recommended):**
     ```bash
     git commit --no-verify

--- a/README.md
+++ b/README.md
@@ -133,7 +133,57 @@ https://eeca-nz.github.io/eeca-python-template/
     If any formatter modifies files or a check fails, the commit will be blocked. After fixing issues or adding modified files, commit again.
 
 *   **Conventional Commits:**
-    The pre-commit and pre-push hooks will enforce commit message conventions. To find out more visit [www.conventionalcommits.org](https://www.conventionalcommits.org)
+    The pre-commit hooks will enforce commit message conventions. To find out more visit [www.conventionalcommits.org](https://www.conventionalcommits.org)
+
+    Common commit types:
+    - `feat`: new feature
+    - `fix`: bug fix
+    - `docs`: documentation only changes
+    - `style`: formatting only (no code changes)
+    - `refactor`: code change that neither fixes a bug nor adds a feature
+    - `test`: adding or fixing tests
+    - `chore`: maintenance tasks (build, deps, configs, etc.)
+
+    Example:  
+    - `feat(auth): add salesforce login`  
+    - `fix(python): correct null values in code`  
+
+### Fixing Old Commits (Conventional Commits)
+    If your commit messages don’t follow the convention and checks fail, you can rewrite them using **interactive rebase**:
+    First, configure VS Code as your Git editor (or skip if you already use a different editor):
+
+    ```bash
+    git config --global core.editor "code -w"
+    ```
+    
+    ```bash
+    # 1) Abort any in-progress rebase (just in case)
+    git rebase --abort || true
+
+    # 2) Switch to your feature branch and update
+    git switch your-feature
+    git fetch origin
+
+    # 3) Pick the correct base branch (choose ONE)
+    BASE=origin/main   # if your PR targets main
+    # BASE=origin/dev  # if your PR targets dev
+    # BASE=origin/test  # if your PR targets test
+
+    # 4) Find the fork point (where your branch split from base)
+    FORK_POINT=$(git merge-base "$BASE" HEAD)
+
+    # (*optional*) sanity check – view the commits you’ll edit
+    git log --oneline --graph --decorate $FORK_POINT..HEAD
+
+    # 5) Start interactive rebase
+    git rebase -i "$FORK_POINT"
+    # -> change 'pick' to 'reword' for the commits to fix
+    # -> enter proper Conventional Commit messages when prompted
+
+    # 6) Push rewritten history safely
+    git push --force-with-lease
+    ```
+    Note: This rewrites commit history. Only do this on your own feature branches, never on shared `main`/`dev`.
 
 *   **Skipping Hooks (not recommended):**
     ```bash

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It is assumed that the developer is working in Ubuntu (typically within `wsl` on
 6.  **Install Pre-commit Hooks:**
     ```bash
     pre-commit install
+    pre-commit install --hook-type commit-msg
     pre-commit install --hook-type pre-push
     ```
 

--- a/README.md
+++ b/README.md
@@ -148,42 +148,43 @@ https://eeca-nz.github.io/eeca-python-template/
     - `feat(auth): add salesforce login`  
     - `fix(python): correct null values in code`  
 
-### Fixing Old Commits (Conventional Commits)
-    If your commit messages don’t follow the convention and checks fail, you can rewrite them using **interactive rebase**:
-    First, configure VS Code as your Git editor (or skip if you already use a different editor):
+## Fixing Old Commits (Conventional Commits)
+If your commit messages don’t follow the convention and checks fail, you can rewrite them using interactive rebase.
 
-    ```bash
-    git config --global core.editor "code -w"
-    ```
-    
-    ```bash
-    # 1) Abort any in-progress rebase (just in case)
-    git rebase --abort || true
-
-    # 2) Switch to your feature branch and update
-    git switch your-feature
-    git fetch origin
-
-    # 3) Pick the correct base branch (choose ONE)
-    BASE=origin/main   # if your PR targets main
-    # BASE=origin/dev  # if your PR targets dev
-    # BASE=origin/test  # if your PR targets test
-
-    # 4) Find the fork point (where your branch split from base)
-    FORK_POINT=$(git merge-base "$BASE" HEAD)
-
-    # (*optional*) sanity check – view the commits you’ll edit
-    git log --oneline --graph --decorate $FORK_POINT..HEAD
-
-    # 5) Start interactive rebase
-    git rebase -i "$FORK_POINT"
-    # -> change 'pick' to 'reword' for the commits to fix
-    # -> enter proper Conventional Commit messages when prompted
-
-    # 6) Push rewritten history safely
-    git push --force-with-lease
-    ```
-    Note: This rewrites commit history. Only do this on your own feature branches, never on shared `main`/`dev`.
+1.Configure VS Code as your Git editor *(Skip this if you already use another editor)*
+```bash
+git config --global core.editor "code -w"
+```
+2.Abort any in-progress rebase (just in case)
+```bash
+git rebase --abort || true
+```
+3.Switch to your feature branch and update
+```bash
+git switch your-feature
+git fetch origin
+```
+4.Pick the correct base branch (choose ONE)
+```bash
+BASE=origin/main   # if your PR targets main
+# BASE=origin/dev  # if your PR targets dev
+# BASE=origin/test  # if your PR targets test
+```
+5.Find the fork point (where your branch split from base)
+```bash
+FORK_POINT=$(git merge-base "$BASE" HEAD)
+```
+6.Start interactive rebase
+```bash
+git rebase -i "$FORK_POINT"
+# change 'pick' to 'reword' for the commits to fix
+# enter proper Conventional Commit messages when 
+```
+7.Push rewritten history safely
+```bash
+git push --force-with-lease
+```
+Note: This rewrites commit history. Only do this on your own feature branches, never on shared `main`/`dev`.
 
 *   **Skipping Hooks (not recommended):**
     ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,8 @@ target-version = ['py311']
 
 [tool.isort]
 profile = "black"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.0"
+tag_format = "v$version"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pre-commit==4.*
 setuptools==80.*
 pip-audit==2.*
 yamllint==1.*
+commitizen==3.*


### PR DESCRIPTION
## Description
This PR introduces conventional commit validation to the repository.

### Changes
- Added a custom pre-push hook (`cz-check-any-branch`) to validate all commits
  against the Conventional Commits spec before pushing.
- Added a `commit-msg` hook from Commitizen to enforce commit message format
  during commit creation.
- Ensured consistent commit message style across contributors

### Benefits
Using Conventional Commits ensures:
- Clear and structured commit history
- Consistency across the team

### Notes
Should re-install hooks after pulling:
```bash
pre-commit install --install-hooks
pre-commit install --hook-type commit-msg
pre-commit install --hook-type pre-push
